### PR TITLE
Removing useEffect for button driven event

### DIFF
--- a/src/components/MovieDetailRow.tsx
+++ b/src/components/MovieDetailRow.tsx
@@ -28,16 +28,15 @@ const MovieDetailRow = (props: MovieDetailRowProps) => {
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const [torrents, setTorrents] = useState<ITorrent[]>();
 
-  useEffect(() => {
-    const getTorrents = async () => {
-      if (!isValidInput(query)) return;
+  const getTorrents = async () => {
+    if (!isValidInput(query)) return;
       const torrents = await prowlarrApi.search(query);
 
       setTorrents(torrents);
       setIsDialogOpen(true);
     };
     getTorrents();
-  }, [query]);
+  }
 
   return (
     <>

--- a/src/components/MovieDetailRow.tsx
+++ b/src/components/MovieDetailRow.tsx
@@ -24,19 +24,16 @@ const prowlarrApi: ProwlarrApi = new ProwlarrApi();
 
 const MovieDetailRow = (props: MovieDetailRowProps) => {
   const { movie } = props;
-  const [query, setQuery] = useState("");
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const [torrents, setTorrents] = useState<ITorrent[]>();
 
-  const getTorrents = async () => {
+  const getTorrents = async (query: string) => {
     if (!isValidInput(query)) return;
-      const torrents = await prowlarrApi.search(query);
+    const torrents = await prowlarrApi.search(query);
 
-      setTorrents(torrents);
-      setIsDialogOpen(true);
-    };
-    getTorrents();
-  }
+    setTorrents(torrents);
+    setIsDialogOpen(true);
+  };
 
   return (
     <>
@@ -48,7 +45,7 @@ const MovieDetailRow = (props: MovieDetailRowProps) => {
             <>
               <Button
                 onClick={() => {
-                  setQuery(movie.searchString);
+                  getTorrents(movie.searchString);
                 }}
                 size="small"
                 variant="contained"


### PR DESCRIPTION
You won't need `const [query, setQuery] = useState("");` for this now that I'm not being dumb and thinking clearly. You can simply just handle this from the button click event by creating a function for the event handler and using it on the button click event. 

I mentioned a debounce in our conversation, I was thinking a text input. Since this is driven from a list with a pre-generated search text that is a property that doesnt change on typing ignore the debounce conversation. Clearly its not needed. 